### PR TITLE
slf4j to 1.7.26-stable (CVE-2018-8088)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,7 +79,7 @@
         <org.b3log.latke.version>2.3.17</org.b3log.latke.version>
 
         <servlet.version>3.1.0</servlet.version>
-        <slf4j.version>1.8.0-beta2</slf4j.version>
+        <slf4j.version>1.7.26</slf4j.version>
         <jsoup.version>1.9.1</jsoup.version>
         <flexmark.version>0.28.18</flexmark.version>
         <qiniu.version>7.0.4.1</qiniu.version>


### PR DESCRIPTION
slf4j to 1.7.26-stable (CVE-2018-8088)
Released after 1.8.0-beta2.